### PR TITLE
ブラックボックステストの仕組みを実装

### DIFF
--- a/backend-svc/docker/Dockerfile
+++ b/backend-svc/docker/Dockerfile
@@ -31,6 +31,9 @@ RUN apt-get install -y \
 RUN useradd neo -m -s /bin/bash \
  && echo 'neo:neo' | chpasswd
 
+# Gem install
+RUN gem install --no-document pry-byebug
+
 #####################################################
 # add scripts
 ADD resources/docker-entrypoint.sh /

--- a/backend-svc/docker/resources/docker-entrypoint.sh
+++ b/backend-svc/docker/resources/docker-entrypoint.sh
@@ -2,6 +2,10 @@
 
 /etc/init.d/ssh start
 
+if [ -n "$TEST" ]; then
+  exec bash -c 'ROUTE=$TEST ruby /mnt/blackbox_test/test_v1.rb'
+fi
+
 bash /mnt/xml_rpc_server/start_server.sh $RPC_SERVER_PORT
 
 echo '----- STARTED -----'

--- a/backend-svc/src/blackbox_test/test_v1.rb
+++ b/backend-svc/src/blackbox_test/test_v1.rb
@@ -26,7 +26,8 @@ class TestV1 < Test::Unit::TestCase
     end
 
     assert_not_equal '', result, 'No response of service!!!'
-    JSON.parse result
+
+    JSON.parse(result, symbolize_names: true)
   end
 
   def test_scenario

--- a/backend-svc/src/blackbox_test/test_v1.rb
+++ b/backend-svc/src/blackbox_test/test_v1.rb
@@ -1,0 +1,166 @@
+require 'test/unit'
+require 'json'
+
+class TestV1 < Test::Unit::TestCase
+
+  def _exec_command(input_data)
+    `ROUTE=#{ENV['ROUTE']} bash /mnt/route.sh 2>/tmp/stderr <<__XXX__\n#{input_data}`
+  end
+
+  def _call_svc(json)
+    if json.is_a? Hash
+      json = JSON.to_json json
+    end
+
+    begin
+      result = _exec_command json
+    rescue => e
+      if result
+        stdout = "\n----- STDOUT -----\n#{result}"
+      end
+      if File.exist? '/tmp/stderr'
+        stderr = "\n----- STDERR -----\n" + File.read('/tmp/stderr')
+      end
+
+      raise "Service error.#{e}#{stdout}#{stderr}"
+    end
+
+    assert_not_equal '', result, 'No response of service!!!'
+    JSON.parse result
+  end
+
+  def test_scenario
+    # 1件登録する
+    json_data = '{"command":"create","options":{"title":"テスト"}}'
+    result = _call_svc(json_data)
+
+    assert_equal 'ok', result[:status]
+
+    # 取得してみる
+    json_data = '{"command":"list","options":{"condition":"all"}}'
+    result = _call_svc(json_data)
+
+    assert_equal 1, result.length
+    assert_equal 'テスト', result[0][:title]
+    assert result[0][:term] == nil || result[0][:term] == ''
+
+    # もう1件登録する
+    json_data = '{"command":"create","options":{"title":"打ち上げに行く"}}'
+    result = _call_svc(json_data)
+
+    assert_equal 'ok', result[:status]
+
+    # 取得してみる
+    json_data = '{"command":"list","options":{"condition":"all"}}'
+    result = _call_svc(json_data)
+
+    assert_equal 2, result.length
+    assert_equal 'テスト', result[0][:title]
+    assert result[0][:term] == nil || result[0][:term] == ''
+    assert_equal '打ち上げに行く', result[1][:title]
+    assert result[1][:term] == nil || result[1][:term] == ''
+
+    entity_id = result[0][:id]
+
+    # 編集
+    json = {
+      command: :edit,
+      options: {
+        id:              entity_id,
+        title:           'テストコードを書く',
+        notify_datetime: '2018-03-20T17:00:00+0900',
+        term:            '2018-03-21T10:30:00+0900',
+        memo:            '実装した新機能のテストコードがまだないので書く'
+      }
+    }
+    result = _call_svc(json_data)
+
+    assert_equal 'ok', result[:status]
+    assert is_iso_date(result[:created_at])
+
+    # 一覧取得
+    json_data = '{"command":"list","options":{"condition":"all"}}'
+    result = _call_svc(json_data)
+
+    assert_equal 2, result.length
+    assert_equal entity_id, result[0][:id]  # IDは変わってないこと
+    assert_equal 'テストコードを書く', result[0][:title]
+    assert_equal '2018-03-21T10:30:00+0900', result[0][:term]
+    assert_equal '打ち上げに行く', result[1][:title]
+    assert result[1][:term] == nil || result[1][:term] == ''
+
+    # 詳細
+    json_data = {
+      command: :detail,
+      options: {
+        id: entity_id
+      }
+    }
+
+    result = _call_svc(json_data)
+
+    assert_equal entity_id, result[:id]
+    assert_equal entity_id, result[0][:id]  # IDは変わってないこと
+    assert_equal 'テストコードを書く', result[0][:title]
+    assert_equal '2018-03-20T17:00:00+0900', result[0][:notify_datetime]
+    assert_equal '2018-03-21T10:30:00+0900', result[0][:term]
+    assert_equal '実装した新機能のテストコードがまだないので書く', result[0][:memo]
+    assert result[:finished_at] == nil || result[:finished_at] == ''
+    assert is_iso_date(result[:created_at])
+    entity1_created_at = result[:created_at]
+
+    # 完了
+    json_data = %Q/{"command":"finish","options":{"id":#{entity_id}}}'/
+    result = _call_svc(json_data)
+
+    assert_equal 'ok', result[:status]
+    assert is_iso_date(result[:finished_at])
+
+    # 詳細
+    json_data = {
+      command: :detail,
+      options: {
+        id: entity_id
+      }
+    }
+
+    result = _call_svc(json_data)
+
+    assert_equal entity_id, result[:id]
+    assert_equal entity_id, result[0][:id]  # IDは変わってないこと
+    assert_equal 'テストコードを書く', result[0][:title]
+    assert_equal '2018-03-20T17:00:00+0900', result[0][:notify_datetime]
+    assert_equal '2018-03-21T10:30:00+0900', result[0][:term]
+    assert_equal '実装した新機能のテストコードがまだないので書く', result[0][:memo]
+    assert is_iso_date(result[:finished_at])
+    assert_equal entity1_created_at, result[:created_at]
+
+    # 削除
+    json_data = %Q/{"command":"delete","options":{"id":#{entity_id}}}/
+    result = _call_svc(json_data)
+
+    assert_equal 'ok', result[:status]
+
+    # 一覧取得
+    json_data = '{"command":"list","options":{"condition":"all"}}'
+    result = _call_svc(json_data)
+
+    assert_equal 1, result.length
+    assert_equal '打ち上げに行く', result[0][:title]
+    entity_id = result[0][:id]
+
+    # 削除
+    json_data = %Q/{"command":"delete","options":{"id":#{entity_id}}}/
+    result = _call_svc(json_data)
+
+    assert_equal 'ok', result[:status]
+
+    # 取得
+    json_data = '{"command":"list","options":{"condition":"all"}}'
+    result = _call_svc(json_data)
+
+    assert_equal 0, result.length
+  end
+
+end
+

--- a/backend-svc/src/blackbox_test/test_v1.rb
+++ b/backend-svc/src/blackbox_test/test_v1.rb
@@ -41,9 +41,9 @@ class TestV1 < Test::Unit::TestCase
     json_data = '{"command":"list","options":{"condition":"all"}}'
     result = _call_svc(json_data)
 
-    assert_equal 1, result.length
-    assert_equal 'テスト', result[0][:title]
-    assert result[0][:term] == nil || result[0][:term] == ''
+    assert_equal 1, result[:list].length
+    assert_equal 'テスト', result[:list][0][:title]
+    assert result[:list][0][:term] == nil || result[:list][0][:term] == ''
 
     # もう1件登録する
     json_data = '{"command":"create","options":{"title":"打ち上げに行く"}}'
@@ -55,13 +55,13 @@ class TestV1 < Test::Unit::TestCase
     json_data = '{"command":"list","options":{"condition":"all"}}'
     result = _call_svc(json_data)
 
-    assert_equal 2, result.length
-    assert_equal 'テスト', result[0][:title]
-    assert result[0][:term] == nil || result[0][:term] == ''
-    assert_equal '打ち上げに行く', result[1][:title]
-    assert result[1][:term] == nil || result[1][:term] == ''
+    assert_equal 2, result[:list].length
+    assert_equal 'テスト', result[:list][0][:title]
+    assert result[:list][0][:term] == nil || result[:list][0][:term] == ''
+    assert_equal '打ち上げに行く', result[:list][1][:title]
+    assert result[:list][1][:term] == nil || result[:list][1][:term] == ''
 
-    entity_id = result[0][:id]
+    entity_id = result[:list][0][:id]
 
     # 編集
     json = {
@@ -83,12 +83,12 @@ class TestV1 < Test::Unit::TestCase
     json_data = '{"command":"list","options":{"condition":"all"}}'
     result = _call_svc(json_data)
 
-    assert_equal 2, result.length
-    assert_equal entity_id, result[0][:id]  # IDは変わってないこと
-    assert_equal 'テストコードを書く', result[0][:title]
-    assert_equal '2018-03-21T10:30:00+0900', result[0][:term]
-    assert_equal '打ち上げに行く', result[1][:title]
-    assert result[1][:term] == nil || result[1][:term] == ''
+    assert_equal 2, result[:list].length
+    assert_equal entity_id, result[:list][0][:id]  # IDは変わってないこと
+    assert_equal 'テストコードを書く', result[:list][0][:title]
+    assert_equal '2018-03-21T10:30:00+0900', result[:list][0][:term]
+    assert_equal '打ち上げに行く', result[:list][1][:title]
+    assert result[:list][1][:term] == nil || result[:list][1][:term] == ''
 
     # 詳細
     json_data = {
@@ -101,11 +101,11 @@ class TestV1 < Test::Unit::TestCase
     result = _call_svc(json_data)
 
     assert_equal entity_id, result[:id]
-    assert_equal entity_id, result[0][:id]  # IDは変わってないこと
-    assert_equal 'テストコードを書く', result[0][:title]
-    assert_equal '2018-03-20T17:00:00+0900', result[0][:notify_datetime]
-    assert_equal '2018-03-21T10:30:00+0900', result[0][:term]
-    assert_equal '実装した新機能のテストコードがまだないので書く', result[0][:memo]
+    assert_equal entity_id, result[:list][0][:id]  # IDは変わってないこと
+    assert_equal 'テストコードを書く', result[:list][0][:title]
+    assert_equal '2018-03-20T17:00:00+0900', result[:list][0][:notify_datetime]
+    assert_equal '2018-03-21T10:30:00+0900', result[:list][0][:term]
+    assert_equal '実装した新機能のテストコードがまだないので書く', result[:list][0][:memo]
     assert result[:finished_at] == nil || result[:finished_at] == ''
     assert is_iso_date(result[:created_at])
     entity1_created_at = result[:created_at]
@@ -128,11 +128,11 @@ class TestV1 < Test::Unit::TestCase
     result = _call_svc(json_data)
 
     assert_equal entity_id, result[:id]
-    assert_equal entity_id, result[0][:id]  # IDは変わってないこと
-    assert_equal 'テストコードを書く', result[0][:title]
-    assert_equal '2018-03-20T17:00:00+0900', result[0][:notify_datetime]
-    assert_equal '2018-03-21T10:30:00+0900', result[0][:term]
-    assert_equal '実装した新機能のテストコードがまだないので書く', result[0][:memo]
+    assert_equal entity_id, result[:list][0][:id]  # IDは変わってないこと
+    assert_equal 'テストコードを書く', result[:list][0][:title]
+    assert_equal '2018-03-20T17:00:00+0900', result[:list][0][:notify_datetime]
+    assert_equal '2018-03-21T10:30:00+0900', result[:list][0][:term]
+    assert_equal '実装した新機能のテストコードがまだないので書く', result[:list][0][:memo]
     assert is_iso_date(result[:finished_at])
     assert_equal entity1_created_at, result[:created_at]
 
@@ -146,9 +146,9 @@ class TestV1 < Test::Unit::TestCase
     json_data = '{"command":"list","options":{"condition":"all"}}'
     result = _call_svc(json_data)
 
-    assert_equal 1, result.length
-    assert_equal '打ち上げに行く', result[0][:title]
-    entity_id = result[0][:id]
+    assert_equal 1, result[:list].length
+    assert_equal '打ち上げに行く', result[:list][0][:title]
+    entity_id = result[:list][0][:id]
 
     # 削除
     json_data = %Q/{"command":"delete","options":{"id":#{entity_id}}}/
@@ -160,7 +160,7 @@ class TestV1 < Test::Unit::TestCase
     json_data = '{"command":"list","options":{"condition":"all"}}'
     result = _call_svc(json_data)
 
-    assert_equal 0, result.length
+    assert_equal 0, result[:list].length
   end
 
 end

--- a/bin/run-docker-compose-blackbox-test.sh
+++ b/bin/run-docker-compose-blackbox-test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(cd $(dirname $0) && pwd)
+
+function exec_backend() {
+  echo "#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=# ROUTE=$1 #=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#=#"
+  TEST=$1 bash $SCRIPT_DIR/run-docker-compose-backend.sh up
+}
+
+if [ -z $1 ]; then
+  echo "$0 <route|'all'>"
+  exit 1
+else
+  bash $SCRIPT_DIR/run-docker-compose-backend.sh build
+  if [ $1 == 'all' ]; then
+    exec_backend 'yamamoto'
+    exec_backend 'yoneoka'
+    exec_backend 'kamada'
+    exec_backend 'moriguchi'
+    exec_backend 'maeda'
+  else
+    exec_backend "$1"
+  fi
+fi
+

--- a/bin/yml/docker-compose-base.yml
+++ b/bin/yml/docker-compose-base.yml
@@ -56,4 +56,5 @@ services:
       - seccomp:unconfined
     environment:
       RPC_SERVER_PORT     :
+      TEST                :
 


### PR DESCRIPTION
#1 の再実装
全サービスルートに対して共通のブラックボックステストを実行できるようにしました。

テスト内容の詳細は、 `backend-svc/src/blackbox_testtest_v1.rb` を参照してください。

#### 使い方
`bin/run-docker-compose-blackbox-test.sh` にルート名を引数で指定して下さい。

#### 例
```
# 山本さんのサービスをテストする場合
bin/run-docker-compose-blackbox-test.sh yamamoto

# 米岡さんのサービスをテストする場合
bin/run-docker-compose-blackbox-test.sh yoneoka

# 鎌田さんのサービスをテストする場合
bin/run-docker-compose-blackbox-test.sh kamada

# 森口さんのサービスをテストする場合
bin/run-docker-compose-blackbox-test.sh moriguchi

# 全ルートを一括テストする場合
bin/run-docker-compose-blackbox-test.sh all
```

確認できたら `:+1:` 下さい。
最後の人はマージしてください。