### PR TITLE
fix:blackbox-test v2 2の期日未到来のテストで指定日時が期日を過ぎている

### DIFF
--- a/backend-svc/src/blackbox_test/test_v2.rb
+++ b/backend-svc/src/blackbox_test/test_v2.rb
@@ -186,7 +186,7 @@ class TestV2 < Test::Unit::TestCase
     json_data = {
       command: :observe,
       options: {
-        current_time: '2019-03-31T23:59:58+09:00',
+        current_time: '2019-03-23T23:58:59+09:00',
         lat:          0.0,
         long:         0.0
       }


### PR DESCRIPTION
期日未到来テストのcurrent_time > 2のterm なので、テスト時にエラーとなる。

```
# もう一つのリマインダーを編集し、１の期限到来と２の通知日時が重なるようにする
command: :edit,
id:              entity2_id,
notify_datetime: '2018-03-21T10:31:00+09:00',
term:            '2019-03-23T23:59:59+09:00',
```
```
# 監視（２の期日未到来）
command: :observe,
current_time: '2019-03-31T23:59:58+09:00',
```
